### PR TITLE
Poprawa testow

### DIFF
--- a/src/test/java/com/kodilla/ecommercee/CartDaoTestSuite.java
+++ b/src/test/java/com/kodilla/ecommercee/CartDaoTestSuite.java
@@ -11,6 +11,8 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
+
+
 import static org.junit.Assert.assertEquals;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -38,15 +40,13 @@ public class CartDaoTestSuite {
         Product product = new Product("product",100);
         Cart cart = new Cart();
 
-        productDao.save(product);
+     //   productDao.save(product);
         userDao.save(user);
         cartDao.save(cart);
 
         cart.setUser(user);
         product.setCart(cart);
-        List<Product> productList = new ArrayList<>();
         cart.getProductList().add(product);
-        cart.setProductList(productList);
 
         productDao.save(product);
         Long productId = product.getId();
@@ -70,7 +70,7 @@ public class CartDaoTestSuite {
 
         //CleanUp
         cartDao.deleteById(cartId);
-        productDao.deleteById(productId);
+       // productDao.deleteById(productId);
         userDao.deleteById(userId);
     }
 
@@ -111,7 +111,7 @@ public class CartDaoTestSuite {
 
         //CleanUp
          cartDao.deleteById(cartId);
-         productDao.deleteById(productId);
+       //  productDao.deleteById(productId);
          userDao.deleteById(userId);
     }
 
@@ -145,7 +145,7 @@ public class CartDaoTestSuite {
         //CleanUp
         cartDao.deleteById(cartId);
         userDao.deleteById(userId);
-        productDao.deleteById(productId);
+       // productDao.deleteById(productId);
     }
 
     @Test

--- a/src/test/java/com/kodilla/ecommercee/OrderDaoTestSuite.java
+++ b/src/test/java/com/kodilla/ecommercee/OrderDaoTestSuite.java
@@ -12,6 +12,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
+
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Optional;
@@ -65,7 +66,6 @@ public class OrderDaoTestSuite {
 
         //CleanUp
         orderDao.deleteById(orderId);
-        cartDao.deleteById(cartId);
         userDao.deleteById(userId);
     }
 
@@ -118,8 +118,6 @@ public class OrderDaoTestSuite {
         //CleanUp
         orderDao.deleteById(orderId);
         orderDao.deleteById(order2Id);
-        cartDao.deleteById(cart2Id);
-        cartDao.deleteById(cartId);
         userDao.deleteById(userId);
         userDao.deleteById(user2Id);
     }
@@ -138,9 +136,9 @@ public class OrderDaoTestSuite {
         User user2 = new User("Mark", "password_Mark");
 
         order.setUser(user);
-        order.setUser(user2);
         order.setCart(cart);
-        order.setCart(cart2);
+        order2.setUser(user2);
+        order2.setCart(cart2);
 
         userDao.save(user);
         Long userId = user.getId();
@@ -149,8 +147,9 @@ public class OrderDaoTestSuite {
         orderDao.save(order);
         Long orderId = order.getId();
         orderDao.save(order2);
-        Long order2Id = order.getId();
+        Long order2Id = order2.getId();
         cartDao.save(cart);
+        cartDao.save(cart2);
 
         //When
         ArrayList<Order> orders = new ArrayList<>();


### PR DESCRIPTION
1). OrderDaoTestSuite:
- usunięcie cartDao.deletById() (ta encja jest usuwana wraz z inną encją równoczesnie)
- zmiana w tescie metody TestOrderDaoFindAll() - było podwojne zapisanie do zmiennej order. Należło to rozdzielić na order i order 2
- dodanie zapisu koszyka do bazy dancyh cartDao.save(cart2)
- zmiana Long order2Id = order.get(id) na Long order2Id = order2.get(id)
(do dwóch zmiennych był przypisany taki sam Id z encji order a id order2 nie było do niczego przypisane)

2. CartDaoTestSuite:
- usunięcie podwójnego zapisu listy produktów w koszyku. Najpierw do koszyka był dodawany produkt a później do koszyk była przypisana pusta Arraylista
- usunięcie productDao.deleteById() encja produkt jest automatycznie usuwana z koszykiem